### PR TITLE
Integrate IOC enrichment storage and resilience

### DIFF
--- a/ioc-enrichment-implementation-status.md
+++ b/ioc-enrichment-implementation-status.md
@@ -1,0 +1,45 @@
+# IOC Enrichment Implementation Status
+
+This document records the current implementation state of the IOC enrichment features described in `ioc-enrichment-implementation.md`. Items are grouped into areas that fully meet the plan and areas that are incomplete or diverge from the design.
+
+## ✅ Implemented as Planned
+
+### Profile Definitions and Management
+* The profile manager loads built-in profiles and optional YAML files, with entries for **IP-basic**, **Domain-basic**, and **Hash-basic** matching the plan’s source lists and metadata. 【F:source/app/iris_engine/enrichment/profiles.py†L15-L154】【F:source/app/iris_engine/enrichment/profiles/default.yaml†L1-L36】
+
+### Normalization and Markdown Output
+* The enrichment normalizer assembles unified IOC results, applies risk scoring rules for IP, domain, and hash data, and annotates classifications and summaries in line with the specification. 【F:source/app/iris_engine/enrichment/normalizer.py†L13-L193】
+* The markdown renderer produces reports with header metadata, executive summaries, key findings, per-source sections, and artifact listings, matching the note-formatting guidance. 【F:source/app/iris_engine/enrichment/markdown_renderer.py†L13-L159】
+
+### GraphQL Exposure
+* GraphQL types, queries, and mutations for enrichment are defined and wired into the global GraphQL schema so clients can request profiles and start jobs through the API surface. 【F:source/app/iris_engine/enrichment/graphql_schema.py†L1-L280】【F:source/app/blueprints/graphql/graphql_route.py†L47-L89】
+
+## ⚠️ Missing or Divergent from Plan
+
+### Source Implementations
+* Several profile sources (OTX, Whois, crt.sh, URLhaus, Hybrid Analysis, MalwareBazaar) return static placeholder payloads instead of live API integrations, so the enrichment data promised in the plan is unavailable. 【F:source/app/iris_engine/enrichment/sources/rdap.py†L53-L147】
+* Other sources in the registry lack configuration plumbing (for example PassiveTotal) or are unused by the shipped profiles, leaving their behaviors untested. 【F:source/app/iris_engine/enrichment/sources/__init__.py†L1-L38】
+
+### Artifact Handling and Note Upserts
+* `run_ioc_enrichment` fabricates in-memory artifact identifiers instead of persisting case artifacts with tags as required. 【F:source/app/iris_engine/enrichment/tasks.py†L141-L156】
+* The helper that should upsert notes always creates a new note and marks a TODO for searching existing notes, so repeated runs are not idempotent. 【F:source/app/iris_engine/enrichment/tasks.py†L220-L256】
+
+### Job Execution Model
+* Enrichment jobs are executed synchronously without Celery task decorators or queue scheduling; the batch helper simply loops over `run_ioc_enrichment`, and the module itself notes that async wiring is still pending. 【F:source/app/iris_engine/enrichment/tasks.py†L46-L197】【F:source/app/iris_engine/enrichment/tasks.py†L259-L299】
+* Because `StartEnrichment` calls the synchronous task directly, GraphQL clients block until completion rather than receiving queued job IDs that transition through statuses. 【F:source/app/iris_engine/enrichment/graphql_schema.py†L95-L144】
+* The in-memory job manager does not persist state across processes or expose the GraphQL status fields described in the plan beyond the lifetime of the worker. 【F:source/app/iris_engine/enrichment/job_manager.py†L16-L200】
+
+### Frontend Experience
+* The IOC table only exposes a “View Enrichment” button for already-populated fields—there is no UI action to trigger profile-based jobs, bulk actions, or the job drawer feedback flow from the plan. 【F:ui/src/pages/alerts.js†L1120-L1199】
+
+### Data Processing Enhancements
+* The enrichment storage manager with artifact/note helpers exists but is not used inside the main task flow, leaving caching, tagging, and state updates inactive. 【F:source/app/iris_engine/enrichment/storage.py†L1-L200】
+* Configuration, caching, rate limiting, and retry utilities are implemented but never invoked during source execution, so API protection and TTL-based reuse are missing. 【F:source/app/iris_engine/enrichment/config.py†L1-L120】【F:source/app/iris_engine/enrichment/tasks.py†L46-L197】
+
+### Miscellaneous Gaps
+* PassiveTotal and Shodan integrations are listed in the registry, yet the shipped default profiles omit them, and no profile gating or RBAC checks exist to reflect the access model outlined in the plan. 【F:source/app/iris_engine/enrichment/profiles/default.yaml†L1-L36】【F:source/app/iris_engine/enrichment/sources/__init__.py†L1-L38】
+* Bulk or differential re-run logic, caching invalidation, and scheduled enrichment hooks from the “Next Steps” section are not present. 【F:source/app/iris_engine/enrichment/tasks.py†L259-L299】【F:source/app/iris_engine/enrichment/config.py†L121-L220】
+
+## Summary
+
+While the scaffolding for profiles, normalization, markdown reporting, and GraphQL endpoints exists, the core enrichment behavior is still largely stubbed. The plan’s promises around real data collection, artifact persistence, idempotent note updates, asynchronous job handling, and analyst-facing UI flows have not been realized yet. Completing those areas will bring the implementation in line with the design intent laid out in `ioc-enrichment-implementation.md`.

--- a/source/app/iris_engine/enrichment/tasks.py
+++ b/source/app/iris_engine/enrichment/tasks.py
@@ -4,27 +4,30 @@ Handles async enrichment jobs with IRIS integration
 """
 
 import logging
-import json
 import uuid
+import time
 from datetime import datetime
 from typing import Dict, Any, List, Optional
 
 from celery import Task
 from celery.signals import task_prerun
-from flask_login import current_user
 
 from app import app, db
 from app.datamgmt.case.case_db import get_case
-from app.datamgmt.case.case_notes_db import get_note, add_note, update_note
-from app.datamgmt.case.case_assets_db import create_asset
 from app.iris_engine.utils.tracker import track_activity
-from iris_interface import IrisInterfaceStatus as IStatus
 
-from .profiles import get_profile, get_profile_manager
+from .profiles import get_profile
 from .sources import SOURCES
 from .normalizer import EnrichmentNormalizer
 from .markdown_renderer import MarkdownRenderer
-from .job_manager import EnrichmentJobManager
+from .job_manager import get_job_manager
+from .storage import get_storage_manager
+from .config import (
+    get_enrichment_config,
+    get_enrichment_cache,
+    get_rate_limiter,
+    get_retry_handler,
+)
 
 log = logging.getLogger(__name__)
 
@@ -63,8 +66,13 @@ def run_ioc_enrichment(case_id: int, ioc_type: str, ioc_value: str,
     if not job_id:
         job_id = str(uuid.uuid4())
 
-    # Initialize job manager
-    job_manager = EnrichmentJobManager()
+    # Initialize service singletons
+    job_manager = get_job_manager()
+    storage_manager = get_storage_manager()
+    config = get_enrichment_config()
+    cache = get_enrichment_cache()
+    rate_limiter = get_rate_limiter()
+    retry_handler = get_retry_handler()
 
     try:
         # Start job tracking
@@ -88,7 +96,7 @@ def run_ioc_enrichment(case_id: int, ioc_type: str, ioc_value: str,
 
         # Execute enrichment sources
         results = {}
-        total_sources = len(profile.sources)
+        total_sources = max(len(profile.sources), 1)
         completed_sources = 0
 
         for source_name in profile.sources:
@@ -103,31 +111,82 @@ def run_ioc_enrichment(case_id: int, ioc_type: str, ioc_value: str,
                     "progress": progress
                 })
 
-                if source_name in SOURCES:
-                    source_class = SOURCES[source_name]
-                    source = source_class()
-
-                    # Fetch data with timeout
-                    source_result = source.fetch(ioc_type, ioc_value, profile.timeout_s)
-                    results[source_name] = source_result
-
-                    if "_error" not in source_result:
-                        log.info(f"Job {job_id}: Successfully fetched data from {source_name}")
-                    else:
-                        log.warning(f"Job {job_id}: Error from {source_name}: {source_result['_error']}")
-                else:
+                if source_name not in SOURCES:
                     log.warning(f"Job {job_id}: Source {source_name} not implemented")
                     results[source_name] = {"_error": f"Source {source_name} not implemented"}
+                    completed_sources += 1
+                    continue
 
-                completed_sources += 1
+                # Check cache first
+                cached_result = cache.get(source_name, ioc_type, ioc_value)
+                if cached_result:
+                    results[source_name] = dict(cached_result)
+                    results[source_name]["_cached"] = True
+                    log.info(f"Job {job_id}: Using cached data for {source_name}")
+                    completed_sources += 1
+                    continue
 
-            except Exception as e:
-                log.error(f"Job {job_id}: Exception fetching from {source_name}: {str(e)}")
-                results[source_name] = {"_error": f"Exception: {str(e)}"}
+                # Enforce rate limiting
+                if not rate_limiter.is_allowed(source_name):
+                    retry_after = rate_limiter.get_retry_after(source_name)
+                    error_msg = (
+                        f"Rate limit exceeded for {source_name}. "
+                        f"Try again in {retry_after:.0f}s"
+                    )
+                    results[source_name] = {"_error": error_msg}
+                    log.warning(f"Job {job_id}: {error_msg}")
+                    completed_sources += 1
+                    continue
+
+                source_class = SOURCES[source_name]
+                source_config = config.get_source_config(source_name)
+                source = source_class(config=source_config)
+
+                max_attempts = 1
+                if config.retry_enabled:
+                    max_attempts = max(config.max_retries, 1)
+
+                attempt = 0
+                source_result: Dict[str, Any] = {}
+
+                while attempt < max_attempts:
+                    attempt += 1
+                    try:
+                        timeout = min(profile.timeout_s, config.max_timeout)
+                        source_result = source.fetch(ioc_type, ioc_value, timeout)
+
+                        if "_error" in source_result:
+                            raise RuntimeError(source_result["_error"])
+
+                        cache.set(source_name, ioc_type, ioc_value, source_result, ttl=profile.cache_ttl)
+                        log.info(f"Job {job_id}: Successfully fetched data from {source_name}")
+                        break
+
+                    except Exception as fetch_error:
+                        error_message = str(fetch_error)
+                        should_retry = retry_handler.should_retry(attempt, fetch_error)
+
+                        if should_retry and attempt < max_attempts:
+                            delay = retry_handler.get_retry_delay(attempt)
+                            log.warning(
+                                f"Job {job_id}: Error from {source_name} (attempt {attempt}/{max_attempts}): "
+                                f"{error_message}. Retrying in {delay:.1f}s"
+                            )
+                            time.sleep(delay)
+                            continue
+
+                        source_result = {"_error": error_message}
+                        log.error(f"Job {job_id}: Failed to fetch {source_name}: {error_message}")
+                        break
+
+                results[source_name] = source_result
                 completed_sources += 1
 
         # Update job status for processing
-        job_manager.update_job_status(job_id, "running", {"phase": "processing_data"})
+        job_manager.update_job_status(job_id, "running", {
+            "phase": "processing_data",
+            "progress": 75
+        })
 
         # Normalize results
         normalizer = EnrichmentNormalizer()
@@ -136,29 +195,41 @@ def run_ioc_enrichment(case_id: int, ioc_type: str, ioc_value: str,
         log.info(f"Job {job_id}: Data normalized, risk score: {normalized_data['summary']['risk_score']}")
 
         # Update job status for artifact creation
-        job_manager.update_job_status(job_id, "running", {"phase": "creating_artifacts"})
+        job_manager.update_job_status(job_id, "running", {
+            "phase": "creating_artifacts",
+            "progress": 85
+        })
 
-        # Store raw data as artifacts
-        artifact_ids = []
+        # Store raw data as artifacts using the storage manager
+        sanitized_results: Dict[str, Dict[str, Any]] = {}
         for source_name, source_data in results.items():
-            if "_error" not in source_data:
-                try:
-                    artifact_content = json.dumps(source_data, indent=2)
-                    artifact_name = f"{source_name}_{ioc_value}_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.json"
+            if isinstance(source_data, dict):
+                cleaned = dict(source_data)
+                cleaned.pop("_cached", None)
+                sanitized_results[source_name] = cleaned
+            else:
+                sanitized_results[source_name] = source_data
 
-                    # Create asset using IRIS create_asset function (simplified for now)
-                    # Note: This needs to be implemented with proper IRIS asset creation
-                    artifact_id = f"artifact_{source_name}_{len(artifact_ids)}"
+        try:
+            artifact_ids = storage_manager.create_enrichment_artifacts_batch(
+                case_id=case_id,
+                enrichment_results=sanitized_results,
+                ioc_value=ioc_value,
+                profile_name=profile_name
+            )
+        except Exception as storage_error:
+            log.error(
+                f"Job {job_id}: Error while creating enrichment artifacts: {storage_error}"
+            )
+            artifact_ids = []
 
-                    if artifact_id:
-                        artifact_ids.append(str(artifact_id))
-                        log.info(f"Job {job_id}: Created artifact {artifact_id} for {source_name}")
-
-                except Exception as e:
-                    log.error(f"Job {job_id}: Failed to create artifact for {source_name}: {str(e)}")
+        artifact_ids = [str(aid) for aid in artifact_ids]
 
         # Update job status for note creation
-        job_manager.update_job_status(job_id, "running", {"phase": "creating_note"})
+        job_manager.update_job_status(job_id, "running", {
+            "phase": "creating_note",
+            "progress": 92
+        })
 
         # Generate markdown report
         renderer = MarkdownRenderer()
@@ -170,7 +241,8 @@ def run_ioc_enrichment(case_id: int, ioc_type: str, ioc_value: str,
 
         # Create or update case note
         note_title = f"IOC Enrichment: {ioc_value}"
-        note_id = upsert_enrichment_note(case_id, note_title, markdown_content, normalized_data)
+        enrichment_block = _wrap_report_with_run_metadata(markdown_content, profile_name)
+        note_id = upsert_enrichment_note(case_id, note_title, enrichment_block)
 
         # Track activity
         if user_id:
@@ -194,6 +266,7 @@ def run_ioc_enrichment(case_id: int, ioc_type: str, ioc_value: str,
         }
 
         job_manager.complete_job(job_id, job_result)
+        job_manager.update_job_status(job_id, "completed", {"progress": 100})
 
         log.info(f"Job {job_id}: Enrichment completed successfully")
         return job_result
@@ -217,43 +290,26 @@ def run_ioc_enrichment(case_id: int, ioc_type: str, ioc_value: str,
         }
 
 
-def upsert_enrichment_note(case_id: int, note_title: str, markdown_content: str,
-                          normalized_data: Dict[str, Any]) -> Optional[int]:
-    """
-    Create or update an enrichment note in the case
+def upsert_enrichment_note(case_id: int, note_title: str, markdown_content: str) -> Optional[int]:
+    """Create or update an enrichment note in the case."""
 
-    Args:
-        case_id: Case ID
-        note_title: Title of the note
-        markdown_content: Markdown content to add
-        normalized_data: Normalized enrichment data for metadata
-
-    Returns:
-        Note ID if successful, None otherwise
-    """
     try:
-        # For now, always create a new note (TODO: implement proper note search)
-        from datetime import datetime
-
-        note_id = add_note(
-            note_title=note_title,
-            creation_date=datetime.utcnow(),
-            user_id=current_user.id if current_user and current_user.is_authenticated else 1,
-            caseid=case_id,
-            directory_id=1,  # Default directory
-            note_content=markdown_content
+        storage_manager = get_storage_manager()
+        note_result = storage_manager.upsert_enrichment_note(
+            case_id=case_id,
+            title=note_title,
+            content=markdown_content,
+            update_mode="prepend",
         )
 
-        if note_id:
-            log.info(f"Created new enrichment note {note_id.note_id if hasattr(note_id, 'note_id') else note_id} for case {case_id}")
-            return note_id.note_id if hasattr(note_id, 'note_id') else note_id
-        else:
-            log.error(f"Failed to create note for case {case_id}")
+        if not note_result:
+            log.error(f"Failed to upsert enrichment note '{note_title}' for case {case_id}")
             return None
 
-    except Exception as e:
-        log.error(f"Failed to create note '{note_title}' for case {case_id}: {str(e)}")
-        return None
+        if hasattr(note_result, "note_id"):
+            return note_result.note_id
+
+        return note_result
 
 
 def batch_ioc_enrichment(case_id: int, ioc_list: List[Dict[str, str]],
@@ -270,16 +326,13 @@ def batch_ioc_enrichment(case_id: int, ioc_list: List[Dict[str, str]],
     Returns:
         List of job IDs for tracking
     """
-    job_ids = []
+    job_ids: List[str] = []
 
     for ioc_data in ioc_list:
         job_id = str(uuid.uuid4())
 
-        # Queue individual enrichment job
-        # In a real implementation, this would use Celery's delay() method
-        # For now, we'll call synchronously but this should be async
         try:
-            result = run_ioc_enrichment(
+            run_ioc_enrichment(
                 case_id=case_id,
                 ioc_type=ioc_data['type'],
                 ioc_value=ioc_data['value'],
@@ -288,11 +341,21 @@ def batch_ioc_enrichment(case_id: int, ioc_list: List[Dict[str, str]],
                 job_id=job_id
             )
             job_ids.append(job_id)
-
         except Exception as e:
-            log.error(f"Failed to queue enrichment for {ioc_data}: {str(e)}")
+            log.error(f"Failed to process enrichment for {ioc_data}: {str(e)}")
 
     return job_ids
+
+
+def _wrap_report_with_run_metadata(report: str, profile_name: str) -> str:
+    """Attach run metadata to the generated markdown report."""
+
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    header = (
+        f"### Enrichment Run — {timestamp}\n"
+        f"*Profile:* **{profile_name}**\n\n"
+    )
+    return f"{header}{report}\n\n---"
 
 
 # Celery task decorators would be applied here in the actual implementation


### PR DESCRIPTION
## Summary
- route IOC enrichment through shared cache, rate limiting, and retry helpers while tracking progress and cache hits
- persist normalized results via the enrichment storage manager so artifacts and notes are created/upserted with run metadata
- sanitize stored outputs and expose a reusable markdown wrapper to prepend successive run blocks in case notes

## Testing
- `python test_enrichment_phase1.py` *(fails: missing YAML dependency and database configuration in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97d934acc8330a6ac14752bf9891a